### PR TITLE
Abdulrahman 7th PR: **Whiteboard MVP – Tutor Interaction, Video & Chat Shell** 

### DIFF
--- a/frontend/src/Components/WhiteboardCanvas.jsx
+++ b/frontend/src/Components/WhiteboardCanvas.jsx
@@ -162,6 +162,21 @@ export default function WhiteboardCanvas() {
         "#0000FF", "#7F00FF", "#FF00FF", "#FF007F"
     ];
 
+
+    /* canvas init */
+    const fitCanvas = () => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const scale  = window.devicePixelRatio || 1;
+        canvas.width  = canvas.clientWidth  * scale;
+        canvas.height = canvas.clientHeight * scale;
+        const ctx = canvas.getContext("2d");
+        ctx.scale(scale, scale);
+        ctx.lineCap = "round";
+        ctx.lineJoin = "round";
+        contextRef.current = ctx;
+    };
+
     /**
      * Set up the canvas size and context for drawing
      */

--- a/frontend/src/Components/WhiteboardCanvas.jsx
+++ b/frontend/src/Components/WhiteboardCanvas.jsx
@@ -137,6 +137,13 @@ function ChatPanel({ tutor, messages, setMessages, onBack }) {
 }
 
 export default function WhiteboardCanvas() {
+
+    /* session state */
+    const [selectedTutor, setSelectedTutor] = useState(null);
+    const [chatMessages, setChatMessages]   = useState([]);
+
+
+
     const canvasRef = useRef(null);
     const contextRef = useRef(null);
 

--- a/frontend/src/Components/WhiteboardCanvas.jsx
+++ b/frontend/src/Components/WhiteboardCanvas.jsx
@@ -2,6 +2,140 @@
 import { useRef, useState, useEffect } from "react";
 import "../Styles/WhiteboardCanvas.css";
 
+/* ────────────────────────────
+   Small inline sub‑components
+──────────────────────────────── */
+const mockTutors = [
+    {
+        id: 1,
+        name: "Dr. Smith",
+        subject: "Physics",
+        avatar: "/avatars/t1.png",
+        status: "online",
+    },
+    {
+        id: 2,
+        name: "Prof. Lin",
+        subject: "Calculus",
+        avatar: "/avatars/t2.png",
+        status: "away",
+    },
+    {
+        id: 3,
+        name: "Ms. Patel",
+        subject: "Chemistry",
+        avatar: "/avatars/t3.png",
+        status: "offline",
+    },
+];
+
+/* Contact list */
+function ContactList({ selectedId, onSelect }) {
+    return (
+        <aside className="lc-panel glass-card contact-list animate-fade-in">
+            <h3 className="panel-title">Tutors</h3>
+            {mockTutors.map((t) => (
+                <button
+                    key={t.id}
+                    className={`contact-card neon-hover ${
+                        selectedId === t.id ? "selected" : ""
+                    }`}
+                    onClick={() => onSelect(t)}
+                >
+                    <span className={`status-dot ${t.status}`} />
+                    {/*<img src={t.avatar} alt={t.name} />*/}
+                    <img src='/assets/images/assignment_icon.png' />
+                    <div>
+                        <div className="contact-name">{t.name}</div>
+                        <div className="contact-subject">{t.subject}</div>
+                    </div>
+                </button>
+            ))}
+        </aside>
+    );
+}
+
+/* ——— VideoView (replace existing block) ——— */
+function VideoView({ tutor, onBack }) {
+    return (
+        <aside className="lc-panel glass-card video-view animate-slide-in-left">
+            <header className="video-header">
+                <button className="icon-btn back-btn" onClick={onBack}>
+                    <i className="fas fa-arrow-left" /> <span className="lbl">Back</span>
+                </button>
+                <span className="video-title">{tutor.name}</span>
+            </header>
+
+            <div className="video-box">
+                {/*<img src={tutor.avatar} alt={tutor.name} />*/}
+                <img src='/assets/images/assignment_icon.png' />
+            </div>
+
+            <footer className="call-controls">
+                {[
+                    ["fas fa-microphone", "Mute"],
+                    ["fas fa-video", "Video"],
+                    ["fas fa-volume-mute", "Deafen"],
+                ].map(([icon, lbl]) => (
+                    <button key={lbl} className="circle-btn icon-btn">
+                        <i className={icon} />
+                        <span className="lbl">{lbl}</span>
+                    </button>
+                ))}
+            </footer>
+        </aside>
+    );
+}
+/* ——— ChatPanel (replace existing block) ——— */
+function ChatPanel({ tutor, messages, setMessages, onBack }) {
+    const inputRef = useRef(null);
+    const listRef  = useRef(null);
+
+    useEffect(() => {
+        listRef.current?.scrollTo(0, listRef.current.scrollHeight);
+    }, [messages]);
+
+    const sendMsg = () => {
+        const txt = inputRef.current.value.trim();
+        if (!txt) return;
+        setMessages((p) => [...p, { id: Date.now(), from: "me", body: txt }]);
+        inputRef.current.value = "";
+        setTimeout(() =>
+            setMessages((p)=>[...p,{id:Date.now()+1,from:tutor.name,body:"👍"}]), 900);
+    };
+
+    return (
+        <aside className="lc-panel glass-card chat-panel animate-slide-in-right">
+            <header className="chat-header">
+                <span>Chat · {tutor.name}</span>
+                <button className="icon-btn back-btn" onClick={onBack}>
+                    <i className="fas fa-times" /><span className="lbl">Close</span>
+                </button>
+            </header>
+
+            <div ref={listRef} className="chat-log">
+                {messages.map((m)=>(
+                    <div key={m.id}
+                         className={`chat-bubble ${m.from==="me"?"sent":"recv"}`}>
+                        {m.body}
+                    </div>
+                ))}
+            </div>
+
+            <div className="chat-input-row">
+                <input
+                    ref={inputRef}
+                    placeholder="Type a message…"
+                    onKeyDown={(e)=>e.key==="Enter"&&sendMsg()}
+                />
+                <button className="send-btn icon-btn" onClick={sendMsg}>
+                    <i className="fas fa-paper-plane" /><span className="lbl">Send</span>
+                </button>
+            </div>
+        </aside>
+    );
+}
+
 export default function WhiteboardCanvas() {
     const canvasRef = useRef(null);
     const contextRef = useRef(null);

--- a/frontend/src/Components/WhiteboardCanvas.jsx
+++ b/frontend/src/Components/WhiteboardCanvas.jsx
@@ -59,13 +59,18 @@ function ContactList({ selectedId, onSelect }) {
 function VideoView({ tutor, onBack }) {
     return (
         <aside className="lc-panel glass-card video-view animate-slide-in-left">
+            {/*<header className="video-header">*/}
+            {/*    <button className="icon-btn back-btn" onClick={onBack}>*/}
+            {/*        <i className="fas fa-arrow-left" /> <span className="lbl">Back</span>*/}
+            {/*    </button>*/}
+            {/*    <span className="video-title">{tutor.name}</span>*/}
+            {/*</header>*/}
             <header className="video-header">
                 <button className="icon-btn back-btn" onClick={onBack}>
                     <i className="fas fa-arrow-left" /> <span className="lbl">Back</span>
                 </button>
                 <span className="video-title">{tutor.name}</span>
             </header>
-
             <div className="video-box">
                 {/*<img src={tutor.avatar} alt={tutor.name} />*/}
                 <img src='/assets/images/assignment_icon.png' />

--- a/frontend/src/Components/WhiteboardCanvas.jsx
+++ b/frontend/src/Components/WhiteboardCanvas.jsx
@@ -155,13 +155,12 @@ export default function WhiteboardCanvas() {
     const [undoStack, setUndoStack] = useState([]);
 
     // Example color palette
-    const colorOptions = [
-        "#000000", "#7F7F7F", "#BFBFBF", "#FFFFFF",
-        "#FF0000", "#FF7F00", "#FFFF00", "#7FFF00",
-        "#00FF00", "#00FF7F", "#00FFFF", "#007FFF",
-        "#0000FF", "#7F00FF", "#FF00FF", "#FF007F"
+    const colors = [
+        "#000000","#7F7F7F","#BFBFBF","#FFFFFF",
+        "#FF0000","#FF7F00","#FFFF00","#7FFF00",
+        "#00FF00","#00FF7F","#00FFFF","#007FFF",
+        "#0000FF","#7F00FF","#FF00FF","#FF007F"
     ];
-
 
     /* canvas init */
     const fitCanvas = () => {

--- a/frontend/src/Components/WhiteboardCanvas.jsx
+++ b/frontend/src/Components/WhiteboardCanvas.jsx
@@ -144,9 +144,11 @@ function ChatPanel({ tutor, messages, setMessages, onBack }) {
 export default function WhiteboardCanvas() {
 
     /* session state */
+    // const [selectedTutor, setSelectedTutor] = useState(null);
+    // const [chatMessages, setChatMessages]   = useState([]);
+    /* session state */
     const [selectedTutor, setSelectedTutor] = useState(null);
     const [chatMessages, setChatMessages]   = useState([]);
-
 
 
     const canvasRef = useRef(null);

--- a/frontend/src/Components/WhiteboardCanvas.jsx
+++ b/frontend/src/Components/WhiteboardCanvas.jsx
@@ -316,6 +316,94 @@ export default function WhiteboardCanvas() {
     }, []);
 
     return (
+
+        <div className="whiteboard-container">
+            <div className="session-container">
+                {/* LEFT PANEL */}
+                {selectedTutor ? (
+                    <VideoView tutor={selectedTutor} onBack={() => setSelectedTutor(null)} />
+                ) : (
+                    <ContactList
+                        selectedId={selectedTutor?.id}
+                        onSelect={(t) => {
+                            setSelectedTutor(t);
+                            setChatMessages([]);    // reset chat per tutor
+                        }}
+                    />
+                )}
+
+                {/* CENTER */}
+                <div className="canvas-column">
+                    {/* primary toolbar */}
+                    <div className="whiteboard-topbar glass-card">
+                        <div className="whiteboard-title">Whiteboard</div>
+                        <div className="whiteboard-tools">
+                            {[
+                                ["Cursor","mouse-pointer"],
+                                ["Pencil","pencil-alt"],
+                                ["Rectangle","square"],
+                                ["Circle","circle"],
+                                ["Eraser","eraser"],
+                            ].map(([t,ic]) => (
+                                <button key={t} title={t} className="tool-btn neon-hover">
+                                    <i className={`fas fa-${ic}`} />
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* secondary toolbar */}
+                    <div className="toolbar glass-card">
+                        <label className="color-label">Color:</label>
+                        {colors.map((c) => (
+                            <button
+                                key={c}
+                                className="color-button"
+                                style={{backgroundColor:c}}
+                                onClick={() => setLineColor(c)}
+                            />
+                        ))}
+                        <label className="width-label">
+                            Brush:
+                            <input
+                                type="range"
+                                min="1" max="20"
+                                value={lineWidth}
+                                onChange={(e)=>setLineWidth(e.target.value)}
+                            />
+                        </label>
+                        {[
+                            ["Clear",clearCanvas],
+                            ["Undo",undo],
+                            ["Download",dlCanvas],
+                        ].map(([t,f])=>(
+                            <button key={t} className="action-button neon-hover" onClick={f}>{t}</button>
+                        ))}
+                    </div>
+
+                    {/* canvas */}
+                    <div
+                        className="canvas-container glass-card"
+                        onMouseDown={startDraw}
+                        onMouseMove={draw}
+                        onMouseUp={stopDraw}
+                        onMouseLeave={stopDraw}
+                    >
+                        <canvas ref={canvasRef} className="drawing-canvas" />
+                    </div>
+                </div>
+
+                {/* RIGHT PANEL */}
+                {selectedTutor && (
+                    <ChatPanel
+                        tutor={selectedTutor}
+                        messages={chatMessages}
+                        setMessages={setChatMessages}
+                        onBack={()=>setSelectedTutor(null)}
+                    />
+                )}
+            </div>
+        </div>
         // Unique parent class to scope styling:
         <div className="whiteboard-container">
             <div className="whiteboard-canvas-container">

--- a/frontend/src/Components/WhiteboardCanvas.jsx
+++ b/frontend/src/Components/WhiteboardCanvas.jsx
@@ -1,32 +1,15 @@
 // WhiteboardCanvas.jsx
 import { useRef, useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import "../Styles/WhiteboardCanvas.css";
 
 /* ────────────────────────────
    Small inline sub‑components
 ──────────────────────────────── */
 const mockTutors = [
-    {
-        id: 1,
-        name: "Dr. Smith",
-        subject: "Physics",
-        avatar: "/avatars/t1.png",
-        status: "online",
-    },
-    {
-        id: 2,
-        name: "Prof. Lin",
-        subject: "Calculus",
-        avatar: "/avatars/t2.png",
-        status: "away",
-    },
-    {
-        id: 3,
-        name: "Ms. Patel",
-        subject: "Chemistry",
-        avatar: "/avatars/t3.png",
-        status: "offline",
-    },
+    { id: 1, name: "Dr. Smith",  subject: "Physics",   avatar: "/avatars/t1.png", status: "online"  },
+    { id: 2, name: "Prof. Lin",  subject: "Calculus",  avatar: "/avatars/t2.png", status: "away"    },
+    { id: 3, name: "Ms. Patel",  subject: "Chemistry", avatar: "/avatars/t3.png", status: "offline" },
 ];
 
 /* Contact list */
@@ -37,14 +20,11 @@ function ContactList({ selectedId, onSelect }) {
             {mockTutors.map((t) => (
                 <button
                     key={t.id}
-                    className={`contact-card neon-hover ${
-                        selectedId === t.id ? "selected" : ""
-                    }`}
+                    className={`contact-card neon-hover ${selectedId === t.id ? "selected" : ""}`}
                     onClick={() => onSelect(t)}
                 >
                     <span className={`status-dot ${t.status}`} />
-                    {/*<img src={t.avatar} alt={t.name} />*/}
-                    <img src='/assets/images/assignment_icon.png' />
+                    <img src="/assets/images/assignment_icon.png" alt="" />
                     <div>
                         <div className="contact-name">{t.name}</div>
                         <div className="contact-subject">{t.subject}</div>
@@ -55,7 +35,12 @@ function ContactList({ selectedId, onSelect }) {
     );
 }
 
-/* ——— VideoView (replace existing block) ——— */
+ContactList.propTypes = {
+    selectedId: PropTypes.number,
+    onSelect:    PropTypes.func.isRequired,
+};
+
+/* ——— VideoView ——— */
 function VideoView({ tutor, onBack }) {
     return (
         <aside className="lc-panel glass-card video-view animate-slide-in-left">
@@ -67,14 +52,13 @@ function VideoView({ tutor, onBack }) {
             </header>
 
             <div className="video-box">
-                {/*<img src={tutor.avatar} alt={tutor.name} />*/}
-                <img src='/assets/images/assignment_icon.png' />
+                <img src="/assets/images/assignment_icon.png" alt="" />
             </div>
 
             <footer className="call-controls">
                 {[
                     ["fas fa-microphone", "Mute"],
-                    ["fas fa-video", "Video"],
+                    ["fas fa-video",       "Video"],
                     ["fas fa-volume-mute", "Deafen"],
                 ].map(([icon, lbl]) => (
                     <button key={lbl} className="circle-btn icon-btn">
@@ -86,7 +70,19 @@ function VideoView({ tutor, onBack }) {
         </aside>
     );
 }
-/* ——— ChatPanel (replace existing block) ——— */
+
+VideoView.propTypes = {
+    tutor: PropTypes.shape({
+        id:      PropTypes.number.isRequired,
+        name:    PropTypes.string.isRequired,
+        subject: PropTypes.string,
+        avatar:  PropTypes.string,
+        status:  PropTypes.string,
+    }).isRequired,
+    onBack: PropTypes.func.isRequired,
+};
+
+/* ——— ChatPanel ——— */
 function ChatPanel({ tutor, messages, setMessages, onBack }) {
     const inputRef = useRef(null);
     const listRef  = useRef(null);
@@ -100,8 +96,14 @@ function ChatPanel({ tutor, messages, setMessages, onBack }) {
         if (!txt) return;
         setMessages((p) => [...p, { id: Date.now(), from: "me", body: txt }]);
         inputRef.current.value = "";
-        setTimeout(() =>
-            setMessages((p)=>[...p,{id:Date.now()+1,from:tutor.name,body:"👍"}]), 900);
+        setTimeout(
+            () =>
+                setMessages((p) => [
+                    ...p,
+                    { id: Date.now() + 1, from: tutor.name, body: "👍" },
+                ]),
+            900
+        );
     };
 
     return (
@@ -109,14 +111,14 @@ function ChatPanel({ tutor, messages, setMessages, onBack }) {
             <header className="chat-header">
                 <span>Chat · {tutor.name}</span>
                 <button className="icon-btn back-btn" onClick={onBack}>
-                    <i className="fas fa-times" /><span className="lbl">Close</span>
+                    <i className="fas fa-times" />
+                    <span className="lbl">Close</span>
                 </button>
             </header>
 
             <div ref={listRef} className="chat-log">
-                {messages.map((m)=>(
-                    <div key={m.id}
-                         className={`chat-bubble ${m.from==="me"?"sent":"recv"}`}>
+                {messages.map((m) => (
+                    <div key={m.id} className={`chat-bubble ${m.from === "me" ? "sent" : "recv"}`}>
                         {m.body}
                     </div>
                 ))}
@@ -126,15 +128,35 @@ function ChatPanel({ tutor, messages, setMessages, onBack }) {
                 <input
                     ref={inputRef}
                     placeholder="Type a message…"
-                    onKeyDown={(e)=>e.key==="Enter"&&sendMsg()}
+                    onKeyDown={(e) => e.key === "Enter" && sendMsg()}
                 />
                 <button className="send-btn icon-btn" onClick={sendMsg}>
-                    <i className="fas fa-paper-plane" /><span className="lbl">Send</span>
+                    <i className="fas fa-paper-plane" />
+                    <span className="lbl">Send</span>
                 </button>
             </div>
         </aside>
     );
 }
+
+ChatPanel.propTypes = {
+    tutor: PropTypes.shape({
+        id:      PropTypes.number.isRequired,
+        name:    PropTypes.string.isRequired,
+        subject: PropTypes.string,
+        avatar:  PropTypes.string,
+        status:  PropTypes.string,
+    }).isRequired,
+    messages:     PropTypes.arrayOf(
+        PropTypes.shape({
+            id:   PropTypes.number.isRequired,
+            from: PropTypes.string.isRequired,
+            body: PropTypes.string.isRequired,
+        })
+    ).isRequired,
+    setMessages:  PropTypes.func.isRequired,
+    onBack:       PropTypes.func.isRequired,
+};
 
 /* ────────────────────────────
    Main component
@@ -145,30 +167,30 @@ export default function WhiteboardCanvas() {
     const [chatMessages, setChatMessages]   = useState([]);
 
     /* drawing state */
-    const canvasRef   = useRef(null);
-    const contextRef  = useRef(null);
+    const canvasRef  = useRef(null);
+    const contextRef = useRef(null);
     const [isDrawing, setIsDrawing] = useState(false);
     const [lineColor, setLineColor] = useState("#000000");
     const [lineWidth, setLineWidth] = useState(3);
     const [undoStack, setUndoStack] = useState([]);
 
     const colors = [
-        "#000000","#7F7F7F","#BFBFBF","#FFFFFF",
-        "#FF0000","#FF7F00","#FFFF00","#7FFF00",
-        "#00FF00","#00FF7F","#00FFFF","#007FFF",
-        "#0000FF","#7F00FF","#FF00FF","#FF007F"
+        "#000000", "#7F7F7F", "#BFBFBF", "#FFFFFF",
+        "#FF0000", "#FF7F00", "#FFFF00", "#7FFF00",
+        "#00FF00", "#00FF7F", "#00FFFF", "#007FFF",
+        "#0000FF", "#7F00FF", "#FF00FF", "#FF007F",
     ];
 
     /* canvas init */
     const fitCanvas = () => {
         const canvas = canvasRef.current;
         if (!canvas) return;
-        const scale  = window.devicePixelRatio || 1;
+        const scale = window.devicePixelRatio || 1;
         canvas.width  = canvas.clientWidth  * scale;
         canvas.height = canvas.clientHeight * scale;
         const ctx = canvas.getContext("2d");
         ctx.scale(scale, scale);
-        ctx.lineCap = "round";
+        ctx.lineCap  = "round";
         ctx.lineJoin = "round";
         contextRef.current = ctx;
     };
@@ -188,33 +210,33 @@ export default function WhiteboardCanvas() {
 
     useEffect(() => {
         if (canvasRef.current && contextRef.current) {
-            const c = canvasRef.current, ctx = contextRef.current;
-            setUndoStack([ctx.getImageData(0,0,c.width,c.height)]);
+            const c = canvasRef.current;
+            setUndoStack([contextRef.current.getImageData(0, 0, c.width, c.height)]);
         }
     }, []);
 
     const pushUndo = () => {
         const c = canvasRef.current;
-        setUndoStack((st) => [...st, contextRef.current.getImageData(0,0,c.width,c.height)]);
+        setUndoStack((st) => [...st, contextRef.current.getImageData(0, 0, c.width, c.height)]);
     };
 
     const undo = () => {
         if (undoStack.length <= 1) return clearCanvas();
         const next = [...undoStack];
         next.pop();
-        contextRef.current.putImageData(next[next.length-1],0,0);
+        contextRef.current.putImageData(next[next.length - 1], 0, 0);
         setUndoStack(next);
     };
 
     /* draw handlers */
-    const startDraw = ({nativeEvent:{offsetX:x,offsetY:y}}) => {
+    const startDraw = ({ nativeEvent: { offsetX: x, offsetY: y } }) => {
         contextRef.current.beginPath();
-        contextRef.current.moveTo(x,y);
+        contextRef.current.moveTo(x, y);
         setIsDrawing(true);
     };
-    const draw = ({nativeEvent:{offsetX:x,offsetY:y}}) => {
+    const draw = ({ nativeEvent: { offsetX: x, offsetY: y } }) => {
         if (!isDrawing) return;
-        contextRef.current.lineTo(x,y);
+        contextRef.current.lineTo(x, y);
         contextRef.current.stroke();
     };
     const stopDraw = () => {
@@ -227,7 +249,7 @@ export default function WhiteboardCanvas() {
     /* util */
     const clearCanvas = () => {
         const c = canvasRef.current;
-        contextRef.current.clearRect(0,0,c.width,c.height);
+        contextRef.current.clearRect(0, 0, c.width, c.height);
     };
     const dlCanvas = () => {
         const link = document.createElement("a");
@@ -246,7 +268,7 @@ export default function WhiteboardCanvas() {
             contextRef.current.globalCompositeOperation = "destination-out";
             setLineWidth(20);
         };
-        const toDraw  = () => {
+        const toDraw = () => {
             contextRef.current.globalCompositeOperation = "source-over";
             setLineWidth(3);
         };
@@ -271,7 +293,7 @@ export default function WhiteboardCanvas() {
                         selectedId={selectedTutor?.id}
                         onSelect={(t) => {
                             setSelectedTutor(t);
-                            setChatMessages([]);    // reset chat per tutor
+                            setChatMessages([]); // reset chat per tutor
                         }}
                     />
                 )}
@@ -283,12 +305,12 @@ export default function WhiteboardCanvas() {
                         <div className="whiteboard-title">Whiteboard</div>
                         <div className="whiteboard-tools">
                             {[
-                                ["Cursor","mouse-pointer"],
-                                ["Pencil","pencil-alt"],
+                                ["Cursor",   "mouse-pointer"],
+                                ["Pencil",   "pencil-alt"],
                                 ["Rectangle","square"],
-                                ["Circle","circle"],
-                                ["Eraser","eraser"],
-                            ].map(([t,ic]) => (
+                                ["Circle",   "circle"],
+                                ["Eraser",   "eraser"],
+                            ].map(([t, ic]) => (
                                 <button key={t} title={t} className="tool-btn neon-hover">
                                     <i className={`fas fa-${ic}`} />
                                 </button>
@@ -303,7 +325,7 @@ export default function WhiteboardCanvas() {
                             <button
                                 key={c}
                                 className="color-button"
-                                style={{backgroundColor:c}}
+                                style={{ backgroundColor: c }}
                                 onClick={() => setLineColor(c)}
                             />
                         ))}
@@ -311,17 +333,20 @@ export default function WhiteboardCanvas() {
                             Brush:
                             <input
                                 type="range"
-                                min="1" max="20"
+                                min="1"
+                                max="20"
                                 value={lineWidth}
-                                onChange={(e)=>setLineWidth(e.target.value)}
+                                onChange={(e) => setLineWidth(Number(e.target.value))}
                             />
                         </label>
                         {[
-                            ["Clear",clearCanvas],
-                            ["Undo",undo],
-                            ["Download",dlCanvas],
-                        ].map(([t,f])=>(
-                            <button key={t} className="action-button neon-hover" onClick={f}>{t}</button>
+                            ["Clear",     clearCanvas],
+                            ["Undo",      undo],
+                            ["Download",  dlCanvas],
+                        ].map(([t, f]) => (
+                            <button key={t} className="action-button neon-hover" onClick={f}>
+                                {t}
+                            </button>
                         ))}
                     </div>
 
@@ -343,11 +368,10 @@ export default function WhiteboardCanvas() {
                         tutor={selectedTutor}
                         messages={chatMessages}
                         setMessages={setChatMessages}
-                        onBack={()=>setSelectedTutor(null)}
+                        onBack={() => setSelectedTutor(null)}
                     />
                 )}
             </div>
         </div>
     );
 }
-

--- a/frontend/src/Styles/WhiteboardCanvas.css
+++ b/frontend/src/Styles/WhiteboardCanvas.css
@@ -1,4 +1,4 @@
-/* WhiteboardCanvas.css */ 
+/* WhiteboardCanvas.css */
 
 /*
    Instead of :root, we're scoping these CSS variables to the

--- a/frontend/src/Styles/WhiteboardCanvas.css
+++ b/frontend/src/Styles/WhiteboardCanvas.css
@@ -274,3 +274,17 @@
     .whiteboard-container .lc-panel { width: 200px; }
     .whiteboard-container .chat-panel { width: 220px; }
 }
+
+.whiteboard-container .tool-btn:hover { color: var(--primary); }
+
+
+.whiteboard-container .neon-hover {
+    transition:
+            transform var(--transition-speed),
+            color var(--transition-speed),
+            box-shadow var(--transition-speed);
+}
+.whiteboard-container .neon-hover:hover {
+    transform: scale(1.15);
+    box-shadow: 0 0 8px var(--neon), 0 0 16px var(--neon);
+}

--- a/frontend/src/Styles/WhiteboardCanvas.css
+++ b/frontend/src/Styles/WhiteboardCanvas.css
@@ -1,4 +1,4 @@
-/* WhiteboardCanvas.css */
+/* WhiteboardCanvas.css */ 
 
 /*
    Instead of :root, we're scoping these CSS variables to the

--- a/frontend/src/Styles/WhiteboardCanvas.css
+++ b/frontend/src/Styles/WhiteboardCanvas.css
@@ -1,9 +1,8 @@
 /* WhiteboardCanvas.css */
 
 /*
-   Instead of :root, we're scoping these CSS variables to the
-   .whiteboard-container so they don't leak globally.
-   If we WANT them truly global, just revert to :root and remove the prefix.
+   We scope variables to .whiteboard-container so they don’t leak globally.
+   If you prefer them global, move the block to :root.
 */
 .whiteboard-container {
     --primary: #00b7c2;
@@ -11,163 +10,42 @@
     --accent: #fda085;
     --glass-bg: rgba(255, 255, 255, 0.25);
     --white-bg: rgba(255, 255, 255, 0.8);
-    --shadow-light: 0px 4px 10px rgba(0, 0, 0, 0.1);
+    --shadow-light: 0 4px 10px rgba(0, 0, 0, 0.08);
     --border-radius: 12px;
     --transition-speed: 0.3s;
-    --font-main: 'Poppins', sans-serif;
+    --font-main: "Poppins", sans-serif;
     --neon: #0ff;
 
-    /* Overall background with layered gradients */
+    /* page bg */
     font-family: var(--font-main);
     min-height: 100vh;
-    margin-top: 50px;
+    margin-top: 60px;
     padding: 1rem;
     background:
-            radial-gradient(circle at top left, rgba(0,255,255,0.15), transparent 50%),
-            radial-gradient(circle at bottom right, rgba(255,0,255,0.15), transparent 50%),
+            radial-gradient(circle at top left,
+            rgba(0, 255, 255, 0.15), transparent 50%),
+            radial-gradient(circle at bottom right,
+            rgba(255, 0, 255, 0.15), transparent 50%),
             linear-gradient(135deg, #e9f0f5, #ffffff);
 }
 
-/* Reset for all children inside .whiteboard-container */
+/* reset */
 .whiteboard-container * {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
 }
 
-/* The main container for the whiteboard layout */
-.whiteboard-container .whiteboard-canvas-container {
-    display: flex;
-    margin-top: 50px;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-/* Glassmorphism style cards */
+/* ──────────────────────────────
+   Base card / layout utilities
+──────────────────────────────── */
 .whiteboard-container .glass-card {
     background: var(--glass-bg);
     backdrop-filter: blur(10px);
     border-radius: var(--border-radius);
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.25);
 }
-
-/* Whiteboard top bar */
-.whiteboard-container .whiteboard-topbar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.6rem 1rem;
-}
-
-.whiteboard-container .whiteboard-title {
-    font-size: 1.3rem;
-    font-weight: 600;
-    color: #333;
-    letter-spacing: 0.5px;
-}
-
-.whiteboard-container .whiteboard-tools {
-    display: flex;
-    gap: 0.6rem;
-}
-
-/* Neon Hover effect */
-.whiteboard-container .neon-hover {
-    transition: transform var(--transition-speed), color var(--transition-speed), box-shadow var(--transition-speed);
-}
-
-.whiteboard-container .neon-hover:hover {
-    transform: scale(1.15);
-    box-shadow: 0 0 8px var(--neon), 0 0 16px var(--neon);
-}
-
-/* Tool buttons */
-.whiteboard-container .tool-btn {
-    background: transparent;
-    border: none;
-    color: #333;
-    font-size: 1.2rem;
-    cursor: pointer;
-    position: relative;
-    transition: color var(--transition-speed);
-}
-
-.whiteboard-container .tool-btn:hover {
-    color: var(--primary);
-}
-
-/* Secondary toolbar */
-.whiteboard-container .toolbar {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    padding: 0.6rem 1rem;
-}
-
-.whiteboard-container .color-label,
-.whiteboard-container .width-label {
-    font-weight: 600;
-    color: #444;
-}
-
-.whiteboard-container .color-button {
-    width: 28px;
-    height: 28px;
-    border: 2px solid transparent;
-    border-radius: 50%;
-    cursor: pointer;
-    transition: transform var(--transition-speed);
-}
-
-.whiteboard-container .color-button:hover {
-    transform: scale(1.2);
-    border-color: #ccc;
-}
-
-.whiteboard-container .width-label input {
-    margin-left: 0.5rem;
-    accent-color: var(--primary);
-}
-
-.whiteboard-container .action-button {
-    background: var(--primary);
-    color: #fff;
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: var(--border-radius);
-    cursor: pointer;
-    transition: background var(--transition-speed), transform var(--transition-speed);
-    font-weight: 600;
-}
-
-.whiteboard-container .action-button:hover {
-    background: var(--primary-dark);
-    transform: scale(1.07);
-}
-
-/* Canvas container */
-.whiteboard-container .canvas-container {
-    border: 2px solid rgba(255, 255, 255, 0.2);
-    border-radius: var(--border-radius);
-    flex: 1;
-    overflow: hidden;
-    min-height: 400px;
-    position: relative;
-    box-shadow: var(--shadow-light);
-}
-
-/* The actual canvas */
-.whiteboard-container .drawing-canvas {
-    width: 100%;
-    height: 100%;
-    min-height: 600px;
-    cursor: crosshair;
-    /* Actual resolution is set in JS */
-}
-
-
 
 /* main flex wrapper */
 .whiteboard-container .session-container {
@@ -185,6 +63,109 @@
     gap: 1rem;
 }
 
+/* ──────────────────────────────
+   Toolbars (top + secondary)
+──────────────────────────────── */
+.whiteboard-container .whiteboard-topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.6rem 1rem;
+}
+
+.whiteboard-container .whiteboard-title {
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: #333;
+}
+
+.whiteboard-container .whiteboard-tools {
+    display: flex;
+    gap: 0.6rem;
+}
+
+.whiteboard-container .tool-btn {
+    background: none;
+    border: none;
+    color: #333;
+    font-size: 1.2rem;
+    cursor: pointer;
+    transition: color var(--transition-speed);
+}
+
+.whiteboard-container .neon-hover {
+    transition:
+            transform var(--transition-speed),
+            color var(--transition-speed),
+            box-shadow var(--transition-speed);
+}
+.whiteboard-container .neon-hover:hover {
+    transform: scale(1.15);
+    box-shadow: 0 0 8px var(--neon), 0 0 16px var(--neon);
+}
+.whiteboard-container .tool-btn:hover { color: var(--primary); }
+
+/* secondary bar */
+.whiteboard-container .toolbar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.6rem 1rem;
+}
+.whiteboard-container .color-label,
+.whiteboard-container .width-label { font-weight: 600; color:#444; }
+
+.whiteboard-container .color-button {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: transform var(--transition-speed);
+}
+.whiteboard-container .color-button:hover {
+    transform: scale(1.2); border-color:#ccc;
+}
+
+.whiteboard-container .width-label input {
+    margin-left: 0.5rem;
+    accent-color: var(--primary);
+}
+
+.whiteboard-container .action-button {
+    background: var(--primary);
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: var(--border-radius);
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--transition-speed), transform var(--transition-speed);
+}
+.whiteboard-container .action-button:hover {
+    background: var(--primary-dark);
+    transform: scale(1.07);
+}
+
+/* ──────────────────────────────
+   Canvas
+──────────────────────────────── */
+.whiteboard-container .canvas-container {
+    flex: 1;
+    min-height: 400px;
+    border: 2px solid rgba(255,255,255,0.25);
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    position: relative;
+    box-shadow: var(--shadow-light);
+}
+.whiteboard-container .drawing-canvas {
+    width: 100%;
+    height: 100%;
+    min-height: 600px;
+    cursor: crosshair;
+}
 
 /* ──────────────────────────────
    Contact list / video / chat
@@ -197,11 +178,7 @@
     gap: 0.6rem;
 }
 
-/* Video view */
-.whiteboard-container .video-view { width: 240px; }
-
-/* Chat panel */
-.whiteboard-container .chat-panel { width: 280px; }
+.panel-title { font-weight: 600; }
 
 /* Contact cards */
 .whiteboard-container .contact-card {
@@ -226,6 +203,42 @@
     background: rgba(255,255,255,0.35);
 }
 
+/* status dots */
+.status-dot {
+    width: 10px; height: 10px;
+    border-radius: 50%;
+    margin-right: 6px;
+    flex-shrink: 0;
+}
+.status-dot.online  { background:#3ecf8e; }
+.status-dot.away    { background:#fcbf49; }
+.status-dot.offline { background:#c4c4c4; }
+
+/* Video view */
+.whiteboard-container .video-view { width: 240px; }
+
+.whiteboard-container .video-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.icon-btn {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1rem;
+    cursor: pointer;
+}
+
+.circle-btn {
+    width: 38px; height: 38px;
+    border-radius: 50%;
+    background: var(--primary);
+    display: flex; align-items: center; justify-content: center;
+}
+.circle-btn:hover { background: var(--primary-dark); }
+
 /* 16:9 video placeholder */
 .whiteboard-container .video-box {
     position: relative;
@@ -241,20 +254,64 @@
     margin: auto;
     width: 60%;
 }
-
-/* ──────────────────────────────
-   Responsiveness
-──────────────────────────────── */
-@media (max-width: 1200px) {
-    .whiteboard-container .lc-panel { width: 200px; }
-    .whiteboard-container .chat-panel { width: 220px; }
+.whiteboard-container .call-controls {
+    margin-top: auto;
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
 }
 
-@media (max-width: 1024px) {
-    /* hide side panels on small/medium screens for focus */
-    .whiteboard-container .lc-panel,
-    .whiteboard-container .chat-panel { display: none; }
+/* Chat panel */
+.whiteboard-container .chat-panel { width: 280px; }
+
+.whiteboard-container .chat-log {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    background: rgba(255,255,255,0.2);
+    padding: 0.6rem;
+    border-radius: var(--border-radius);
+    max-height: 900px;
 }
+.whiteboard-container .chat-bubble {
+    padding: 0.4rem 0.6rem;
+    border-radius: 14px;
+    max-width: 85%;
+    line-height: 1.3;
+}
+.whiteboard-container .chat-bubble.sent {
+    align-self: flex-end;
+    background: var(--primary);
+    color: #fff;
+}
+.whiteboard-container .chat-bubble.recv {
+    align-self: flex-start;
+    background: var(--white-bg);
+}
+
+.whiteboard-container .chat-input-row {
+    display: flex;
+    gap: 0.4rem;
+}
+.whiteboard-container .chat-input-row input {
+    flex: 1;
+    border: none;
+    padding: 0.4rem 0.6rem;
+    border-radius: var(--border-radius);
+}
+.whiteboard-container .chat-input-row button {
+    background: var(--primary);
+    border: none;
+    color: #fff;
+    padding: 0 0.8rem;
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    transition: transform var(--transition-speed);
+}
+.whiteboard-container .chat-input-row button:hover { transform: scale(1.1); }
+
 /* ──────────────────────────────
    Animations
 ──────────────────────────────── */
@@ -268,25 +325,18 @@
 .whiteboard-container .animate-slide-in-left  { animation:slideInLeft  .35s ease-out; }
 .whiteboard-container .animate-slide-in-right { animation:slideInRight .35s ease-out; }
 
-
-
+/* ──────────────────────────────
+   Responsiveness
+──────────────────────────────── */
 @media (max-width: 1200px) {
     .whiteboard-container .lc-panel { width: 200px; }
     .whiteboard-container .chat-panel { width: 220px; }
 }
 
-.whiteboard-container .tool-btn:hover { color: var(--primary); }
-
-
-.whiteboard-container .neon-hover {
-    transition:
-            transform var(--transition-speed),
-            color var(--transition-speed),
-            box-shadow var(--transition-speed);
-}
-.whiteboard-container .neon-hover:hover {
-    transform: scale(1.15);
-    box-shadow: 0 0 8px var(--neon), 0 0 16px var(--neon);
+@media (max-width: 1024px) {
+    /* hide side panels on small/medium screens for focus */
+    .whiteboard-container .lc-panel,
+    .whiteboard-container .chat-panel { display: none; }
 }
 
 /* ——— labelled icon buttons ——— */
@@ -306,3 +356,10 @@
 /* tighten call‑control layout */
 .call-controls .circle-btn { flex-direction:column; font-size:0.85rem; }
 .call-controls .lbl { margin:0; }
+
+/* add slight hover pop */
+.circle-btn:hover, .send-btn:hover, .back-btn:hover {
+    transform:scale(1.1);
+    transition:transform 0.2s;
+}
+

--- a/frontend/src/Styles/WhiteboardCanvas.css
+++ b/frontend/src/Styles/WhiteboardCanvas.css
@@ -166,3 +166,40 @@
     cursor: crosshair;
     /* Actual resolution is set in JS */
 }
+
+
+
+/* main flex wrapper */
+.whiteboard-container .session-container {
+    display: flex;
+    gap: 1rem;
+    min-height: calc(100vh - 80px);
+}
+
+/* center column so canvas + bars stick together */
+.whiteboard-container .canvas-column {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+
+/* ──────────────────────────────
+   Contact list / video / chat
+──────────────────────────────── */
+.whiteboard-container .lc-panel {
+    width: 240px;
+    display: flex;
+    flex-direction: column;
+    padding: 0.8rem;
+    gap: 0.6rem;
+}
+
+/* Video view */
+.whiteboard-container .video-view { width: 240px; }
+
+/* Chat panel */
+.whiteboard-container .chat-panel { width: 280px; }
+

--- a/frontend/src/Styles/WhiteboardCanvas.css
+++ b/frontend/src/Styles/WhiteboardCanvas.css
@@ -203,3 +203,55 @@
 /* Chat panel */
 .whiteboard-container .chat-panel { width: 280px; }
 
+/* Contact cards */
+.whiteboard-container .contact-card {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 0.4rem;
+    background: transparent;
+    border: none;
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    text-align: left;
+    transition: background var(--transition-speed);
+}
+.whiteboard-container .contact-card img {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+}
+.whiteboard-container .contact-card.selected,
+.whiteboard-container .contact-card:hover {
+    background: rgba(255,255,255,0.35);
+}
+
+/* 16:9 video placeholder */
+.whiteboard-container .video-box {
+    position: relative;
+    width: 100%;
+    padding-top: 56.25%;
+    background: #000;
+    border-radius: var(--border-radius);
+    overflow: hidden;
+}
+.whiteboard-container .video-box img {
+    position: absolute;
+    inset: 0;
+    margin: auto;
+    width: 60%;
+}
+
+/* ──────────────────────────────
+   Responsiveness
+──────────────────────────────── */
+@media (max-width: 1200px) {
+    .whiteboard-container .lc-panel { width: 200px; }
+    .whiteboard-container .chat-panel { width: 220px; }
+}
+
+@media (max-width: 1024px) {
+    /* hide side panels on small/medium screens for focus */
+    .whiteboard-container .lc-panel,
+    .whiteboard-container .chat-panel { display: none; }
+}

--- a/frontend/src/Styles/WhiteboardCanvas.css
+++ b/frontend/src/Styles/WhiteboardCanvas.css
@@ -288,3 +288,21 @@
     transform: scale(1.15);
     box-shadow: 0 0 8px var(--neon), 0 0 16px var(--neon);
 }
+
+/* ——— labelled icon buttons ——— */
+.icon-btn { display:flex; align-items:center; gap:4px; color:#fff; }
+.icon-btn .lbl { font-size:0.75rem; }
+
+/* keep labels readable on white buttons */
+.send-btn, .back-btn { background: none; color: inherit; }
+
+/* video/header titles */
+.video-title { font-weight:600; }
+.chat-header {
+    display:flex; justify-content:space-between; align-items:center;
+    margin-bottom:0.4rem;
+}
+
+/* tighten call‑control layout */
+.call-controls .circle-btn { flex-direction:column; font-size:0.85rem; }
+.call-controls .lbl { margin:0; }

--- a/frontend/src/Styles/WhiteboardCanvas.css
+++ b/frontend/src/Styles/WhiteboardCanvas.css
@@ -255,3 +255,15 @@
     .whiteboard-container .lc-panel,
     .whiteboard-container .chat-panel { display: none; }
 }
+/* ──────────────────────────────
+   Animations
+──────────────────────────────── */
+@keyframes fadeIn      { from {opacity:0}                 to {opacity:1} }
+@keyframes slideInLeft { from {transform:translateX(-20px);opacity:0}
+    to   {transform:none;opacity:1} }
+@keyframes slideInRight{ from {transform:translateX( 20px);opacity:0}
+    to   {transform:none;opacity:1} }
+
+.whiteboard-container .animate-fade-in        { animation:fadeIn       .35s ease-out; }
+.whiteboard-container .animate-slide-in-left  { animation:slideInLeft  .35s ease-out; }
+.whiteboard-container .animate-slide-in-right { animation:slideInRight .35s ease-out; }

--- a/frontend/src/Styles/WhiteboardCanvas.css
+++ b/frontend/src/Styles/WhiteboardCanvas.css
@@ -267,3 +267,10 @@
 .whiteboard-container .animate-fade-in        { animation:fadeIn       .35s ease-out; }
 .whiteboard-container .animate-slide-in-left  { animation:slideInLeft  .35s ease-out; }
 .whiteboard-container .animate-slide-in-right { animation:slideInRight .35s ease-out; }
+
+
+
+@media (max-width: 1200px) {
+    .whiteboard-container .lc-panel { width: 200px; }
+    .whiteboard-container .chat-panel { width: 220px; }
+}


### PR DESCRIPTION
_Closes out Whiteboard MVP by adding the full communication wrapper (Issues #135, #137) and refines UI polish from PR #145._

---
### **Branch:** `whiteboard-video-and-chat-MVP`
---

## Overview  
This PR layers **tutor‑selection, simulated video call, and contextual chat** on top of the drawing canvas delivered in PR #145. The result is a cohesive, single‑page teaching workspace that meets the remaining Whiteboard MVP requirements (UC6 – UC10) and aligns with the flow discussed in Discussion #134.

---

## Key Features & Changes  

| Area | Feature | Notes |
|------|---------|-------|
| **Tutor Contact Panel** | • Scrollable list with avatar, subject, status dot<br>• Selection highlight & fade‑in animation | Issue #135 |
| **Simulated Video View** | • 16 × 9 placeholder feed<br>• Back button, Mute / Video / Deafen controls (labeled)<br>• Slide‑in transition | Issue #135 |
| **Contextual Chat Panel** | • Appears only when tutor selected<br>• Header shows tutor name + close button<br>• Auto‑scroll, Enter‑to‑send, simulated replies | Issue #137 |
| **Refined Canvas Toolbar** | • Hover pop + neon glow on icons<br>• Labeled Undo / Clear / Download actions | polish |
| **Global UI Polish** | • Status dots (online/away/offline)<br>• Icon‑with‑label buttons<br>• Smooth slide/fade animations<br>• Medium‑screen breakpoints hide side panels for focus | design consistency |

---

## Implementation Notes  

* **Single‑file integration** — all logic lives in `WhiteboardCanvas.jsx` and `WhiteboardCanvas.css`, avoiding asset sprawl.  
* **State‑driven layout** — `selectedTutor && …` gates video + chat, ensuring zero rendering overhead when idle.  
* **CSS variables & glassmorphism** shared with PR #145 for theme cohesion.  
* **No backend calls yet** — tutor data and chat replies remain mocked; sockets will arrive post‑MVP (see *Future Work*).

---

## Design Alignment  

| UC | Description | Delivered? |
|----|-------------|------------|
| **UC6** | Select tutor from list | ✅ |
| **UC7** | Start / leave video session | ✅ (simulated) |
| **UC8** | Mute / disable video / deafen | ✅ (UI controls) |
| **UC9** | Open contextual chat | ✅ |
| **UC10** | Send / receive messages | ✅ (mocked replies) |

Diagrams from DP1/DP2 remain accurate; only the contact‑list state machine gained a *Back → Contacts* transition (updated in DP3).

---

## Related Items  

* **Issues Closed:** 
* #135  
* #137 
* **Continues Discussion:** #134 
* **Builds On:** #145 

---

## How to Test  

1. `npm run dev` (front‑end)  
2. Go to **/Student/LandingPage** or **/tutor/LandingPage** → click **Launch Whiteboard**.  
3. **Select a tutor** from the left panel.  
   * Expected: contact list fades out, video panel slides in, chat panel appears right.  
4. **Interact**:  
   * Click **Mute / Video / Deafen** buttons (labels visible).  
   * Send chat messages → bot replies with 👍 after ~1 s.  
   * Draw, Clear, Undo, Download still work.  
5. Click **Back** (video) or **Close** (chat) → return to contact list; canvas state is preserved.  
6. Shrink viewport to ≤ 1024 px → side panels auto‑hide, canvas goes full‑width.

---

## 📂 Files Added/Modified  

| File | Type | Purpose |
|------|------|---------|
| `WhiteboardCanvas.jsx` | **M** | Adds ContactList, VideoView, ChatPanel sub‑components + session state |
| `WhiteboardCanvas.css` | **M** | Adds panel layout, animations, icon‑label styles, responsive rules |
| *No new assets* |   | Re‑used existing avatar placeholders |

---

## Future Work  

* **Realtime sockets** for multi‑user drawing & chat (back‑end ticket forthcoming).  
* **Shape / text tools** and **layered undo**.  
* **Accessibility pass** – aria labels, keyboard nav, high‑contrast theme toggle.  
* **Unit tests** for toolbar actions & chat auto‑scroll.  

---

## ✅ Reviewer Checklist  

- [x] Side‑panels render & animate correctly on tutor select / back  
- [x] Chat auto‑scrolls and sends mock replies  
- [x] Canvas tools (color, brush, undo, clear, download) behave as in PR #145  
- [x] CSS scoped to `.whiteboard-container`; no global leaks  
- [x] No console errors / warnings  

---
## Design Diagrams

These diagrams visualize the system behaviors and user flows introduced in this PR. They clarify how the MVP communication shell integrates drawing, video, and chat into a unified tutoring experience.


![Diagram](https://github.com/user-attachments/assets/15790752-d926-4d7b-86fd-03d52abc8ca2)


### MVP Prototype (Current PR)
This wireframe represents the **final layout of the Whiteboard MVP** following PR #145 . It includes:
- A top **navigation bar** for app-wide actions  
- A **video call panel** on the left, simulating a tutor-student session  
- The **main canvas** at the center for real-time drawing  
- A **chat panel** on the right that appears contextually when a tutor is selected  

> The prototype directly informed the layout coded in `WhiteboardCanvas.jsx`, with state-controlled visibility and responsive resizing for different devices.
![Prototype_MVP](https://github.com/user-attachments/assets/eda64e67-2588-4723-a21d-61dc92aa60ed)

### **Use Case Diagram – Whiteboard MVP**
This diagram models student interactions across three primary functions:
- 🎯 **Select a Tutor** → launches a simulated view interface  
- ✏️ **Draw on Canvas** → enables tools like pencil/eraser  
- 💬 **Chat with Tutor** → triggers contextual messaging pane  

> Each top-level action includes system responses and tool usage, aligning with UC6–UC10 from the Design Portfolio requirements.
![UseCaseDiagram–LessonConnectWhiteboardMVP](https://github.com/user-attachments/assets/f4682685-f742-4c09-9332-17743686d34e)

### **Sequence Diagram – Drawing & Download Flow**
This diagram shows the **real-time user interaction sequence**:
1. Student clicks a tutor → triggers `setTutor()` and video panel render  
2. Canvas interaction begins (`startDrawing`, `drawLine()`, `stopLine()`)  
3. Chat messages (`sendMessage()`) propagate through the UI → auto-scroll, bot reply, and display  

> This diagram emphasizes the state-driven rendering logic and the separation of concerns between UI panels. It reflects how drawing and messaging functions co-exist within the `WhiteboardCanvas.jsx` session state.

![SequenceDiagram–WhiteboardSessionFlow](https://github.com/user-attachments/assets/5ae1f5d7-b572-448b-b8b2-060387b6ebbd)

### Current Website MVP
![Current_Website](https://github.com/user-attachments/assets/9a1a1740-e170-4af8-977a-555dd672f436)
![Current_Website_Chat](https://github.com/user-attachments/assets/1f0b3689-3187-4fa4-88d1-dcdc5b2f66ce)


---
## AI Code Usage  

- **Planning only** — ChatGPT/Copilot were used for brainstorming layout variants.  
- **All committed code** is hand‑written and reviewed for consistency with project standards.

---

Thanks for reviewing this **end‑to‑end Whiteboard MVP**!  
Feedback—especially on UI feel & accessibility—is welcome.  

**— Abdulrahman**
